### PR TITLE
implement scheduler.Clone allowing to start a new process that executes a function

### DIFF
--- a/Kernel/src/Bin/BasicShell.d
+++ b/Kernel/src/Bin/BasicShell.d
@@ -203,30 +203,6 @@ private:
 				}
 			}
 			break;
-
-		case "task":
-			import Task.Scheduler;
-
-			if (cmd.args.length == 1)
-				goto task_help;
-
-			switch (cmd.args[1]) {
-			case "die":
-				scr.Writeln("Will now die, aka NEVER RETURN!");
-				GetScheduler.SwitchProcess(false);
-				break;
-			case "yield":
-				scr.Writeln("Will now yield, aka switch process!");
-				GetScheduler.SwitchProcess(true);
-				break;
-			default:
-				goto task_help;
-			}
-			break;
-
-		task_help:
-			scr.Writeln("task <die/yield>");
-			break;
 		default:
 			scr.Writeln("Unknown command: ", cmd.args[0], ". Type 'help' for all the commands.");
 			break;

--- a/Kernel/src/Bin/BasicShell.d
+++ b/Kernel/src/Bin/BasicShell.d
@@ -3,6 +3,7 @@ module Bin.BasicShell;
 import Data.TextBuffer : scr = GetBootTTY;
 import IO.Keyboard;
 import Data.String;
+import Data.Address;
 import IO.Log;
 import Memory.Heap;
 
@@ -14,6 +15,14 @@ import HW.BGA.BGA;
 import Memory.FrameAllocator;
 import CPU.PIT;
 import HW.CMOS.CMOS;
+
+VirtAddress RunBasicShell()
+{
+	auto shell = new BasicShell();
+	shell.MainLoop();
+	shell.destroy();
+	return VirtAddress(0);
+}
 
 class BasicShell {
 public:

--- a/Kernel/src/CPU/GDT.d
+++ b/Kernel/src/CPU/GDT.d
@@ -162,12 +162,12 @@ private:
 		SetData(idx++, true, 0);
 
 		// User
-		SetData(idx++, true, 3);
 		SetCode(idx++, true, 3, true);
+		SetData(idx++, true, 3);
 
 		tssID = cast(ushort)idx;
-		SetTSS(idx++, tss); // Uses 2 entries
-		idx++;
+		SetTSS(idx, tss); // Uses 2 entries
+		idx += 2;
 		return idx;
 	}
 }

--- a/Kernel/src/KMain.d
+++ b/Kernel/src/KMain.d
@@ -53,22 +53,17 @@ extern (C) int kmain(uint magic, ulong info) {
 	asm {
 		sti;
 	}
-	/+
-		//if (fork()) {
-		auto shell = new BasicShell();
-		shell.MainLoop();
-		shell.destroy();
-		//}
-	+/
 
-	import Task.Process : switchToUserMode;
+	GetScheduler.Clone(&RunBasicShell, VirtAddress(0), "BasicShell");
+
+	/*import Task.Process : switchToUserMode;
 
 	enum StackSize = 0x1000;
 	VirtAddress stack = VirtAddress(new ubyte[StackSize].ptr) + StackSize;
 
 	scr.Writeln("Moving to userspace!");
 
-	switchToUserMode(cast(ulong)&userspace, stack.Int);
+	switchToUserMode(cast(ulong)&userspace, stack.Int);*/
 
 	while (true) {
 	}

--- a/Kernel/src/Memory/Paging.d
+++ b/Kernel/src/Memory/Paging.d
@@ -197,7 +197,7 @@ class Paging {
 		return phys;
 	}
 
-	TablePtr!void* GetPage(VirtAddress virt) {
+	TablePtr!(void)* GetPage(VirtAddress virt) {
 		if (virt.Int == 0)
 			return null;
 		const ulong virtAddr = virt.Int;

--- a/Kernel/src/Task/Process.d
+++ b/Kernel/src/Task/Process.d
@@ -6,6 +6,8 @@ import Memory.Heap;
 
 extern (C) void switchToUserMode(ulong loc, ulong stack);
 
+alias PID = ulong;
+
 struct ThreadState {
 	VirtAddress rbp;
 	VirtAddress rsp;
@@ -29,7 +31,7 @@ enum ProcessState {
 }
 
 struct Process {
-	ulong pid;
+	PID pid;
 	string name;
 	string description;
 
@@ -38,6 +40,8 @@ struct Process {
 
 	ulong uid;
 	ulong gid;
+
+	PID parent;
 
 	ulong returnCode;
 	ProcessState state;

--- a/Kernel/src/Task/Scheduler.d
+++ b/Kernel/src/Task/Scheduler.d
@@ -200,6 +200,7 @@ private:
 			mov RBP, storeRBP[RAX];
 			mov RSP, storeRSP[RAX];
 			mov RAX, SWITCH_MAGIC;
+			sti;
 			jmp RBX;
 		}
 	}

--- a/Kernel/src/Task/Scheduler.d
+++ b/Kernel/src/Task/Scheduler.d
@@ -59,31 +59,36 @@ public:
 		return PID.max;
 	}
 
-	PID Clone() {
-		/+	Process* process = new Process();
-		VirtAddress stack = VirtAddress(new ubyte[StackSize].ptr) + StackSize;
-		memcpy(stack.ptr, current.image.stack)
+	VirtAddress Join(PID p) {
+		// Joins a finished process
+		return VirtAddress(0);
+	}
 
+	PID Clone(VirtAddress function() func, VirtAddress stack = VirtAddress(0), string _name = current.name) {
+		if(stack == 0)
+			stack = VirtAddress(new ubyte[StackSize].ptr) + StackSize;
+
+		Process* process = new Process();
 		with (process) {
 			pid = getFreePid;
-			name = current.name.dup;
+			name = _name.dup;
 			uid = current.uid;
 			gid = current.gid;
 
-			/*threadState.rip = VirtAddress(0);
+			threadState.rip = VirtAddress(func);
 			threadState.rbp = VirtAddress(0);
-			threadState.rsp = VirtAddress(0);*/
+			threadState.rsp = stack;
 			threadState.fpuEnabled = current.threadState.fpuEnabled;
 			threadState.paging = current.threadState.paging;
 
-			image.stack = VirtAddress(&KERNEL_STACK_START) + 1 /*???*/ ;
+			image.stack = stack;
 
-			state = ProcessState.Running;
-			active = true;
-		}+/
+			state = ProcessState.Waiting;
+			active = false;
+		}
 
-		// Clones everything but the paging, which is reused
-		return PID.max;
+		processes.Add(process);
+		return process.pid;
 	}
 
 	@property Process* CurrentProcess() {
@@ -145,7 +150,7 @@ private:
 	void initKernel() {
 		import Memory.Paging : GetKernelPaging;
 
-		initProcess = new Process();
+		current = initProcess = new Process();
 		with (initProcess) {
 			pid = 1;
 			name = "Init";
@@ -174,7 +179,10 @@ private:
 	}
 
 	void doSwitching() {
+		import IO.Log : log;
+		log.Info("Switching from : ", current.name);
 		current = nextProcess();
+		log.Info("Switching to   : ", current.name);
 
 		ulong storeRIP = current.threadState.rip;
 		ulong storeRBP = current.threadState.rbp;

--- a/Kernel/src/Task/Scheduler.d
+++ b/Kernel/src/Task/Scheduler.d
@@ -179,10 +179,7 @@ private:
 	}
 
 	void doSwitching() {
-		import IO.Log : log;
-		log.Info("Switching from : ", current.name);
 		current = nextProcess();
-		log.Info("Switching to   : ", current.name);
 
 		ulong storeRIP = current.threadState.rip;
 		ulong storeRBP = current.threadState.rbp;

--- a/Kernel/src/Task/Task.S
+++ b/Kernel/src/Task/Task.S
@@ -13,11 +13,15 @@ switchToUserMode: // RIP = %rdi, RSP = %rsi
 	mov %ax, %es
 	mov %ax, %fs
 	mov %ax, %gs
-	mov %ax, %ss
+	mov %rsi, %rsp
+
+	push $0x0
+	mov %rsp, %rax
+
 	push $USER_SS
 
 	// Stack pointer
-	push %rsi
+	push %rax
 
 	// FLAGS, Enabling interrupt
 	pushfq

--- a/Kernel/src/object.d
+++ b/Kernel/src/object.d
@@ -136,7 +136,7 @@ extern (C) {
 
 	// the compiler spits this out all the time
 	Object _d_newclass(const ClassInfo ci) {
-		log.Debug("Creating a new class of type: ", ci.name);
+		//log.Debug("Creating a new class of type: ", ci.name);
 		void* memory = GetKernelHeap.Alloc(ci.init.length);
 		if (memory is null) {
 			log.Fatal("\n\n_d_newclass malloc failure\n\n");


### PR DESCRIPTION
Implements `Scheduler.Clone(func, stack, name)` and fixes switching processes within a timer interrupt not reenabling interrupts