### PR TITLE
Less Busy waiting

### DIFF
--- a/.gdb_history
+++ b/.gdb_history
@@ -1,0 +1,22 @@
+target remote :1234
+c
+b ffffffff8010119d
+b 0xffffffff8010119d
+b cloneHelper
+c
+q
+set architecture i386:x86-64:intel
+b cloneHelper
+target remote :1234
+c
+q
+target remote :1234
+b cloneHelper
+c
+help
+stack
+status
+tracepoints
+c
+c
+q

--- a/Kernel/src/Bin/BasicShell.d
+++ b/Kernel/src/Bin/BasicShell.d
@@ -203,30 +203,6 @@ private:
 				}
 			}
 			break;
-
-		case "task":
-			import Task.Scheduler;
-
-			if (cmd.args.length == 1)
-				goto task_help;
-
-			switch (cmd.args[1]) {
-			case "die":
-				scr.Writeln("Will now die, aka NEVER RETURN!");
-				GetScheduler.SwitchProcess(false);
-				break;
-			case "yield":
-				scr.Writeln("Will now yield, aka switch process!");
-				GetScheduler.SwitchProcess(true);
-				break;
-			default:
-				goto task_help;
-			}
-			break;
-
-		task_help:
-			scr.Writeln("task <die/yield>");
-			break;
 		default:
 			scr.Writeln("Unknown command: ", cmd.args[0], ". Type 'help' for all the commands.");
 			break;

--- a/Kernel/src/Bin/BasicShell.d
+++ b/Kernel/src/Bin/BasicShell.d
@@ -5,6 +5,7 @@ import IO.Keyboard;
 import Data.String;
 import IO.Log;
 import Memory.Heap;
+import Task.Scheduler;
 
 import ACPI.RSDP;
 import KMain;
@@ -100,7 +101,7 @@ private:
 	void execute(Command* cmd) {
 		switch (cmd.args[0]) {
 		case "help":
-			scr.Writeln("Commands: help, echo, clear, exit, memory, time, ls, cd, cat");
+			scr.Writeln("Commands: help, echo, clear, exit, memory, time, sleep, ls, cd, cat");
 			break;
 
 		case "echo":
@@ -135,6 +136,13 @@ private:
 			scr.Writeln("The machine booted at: ", timestamp);
 			scr.Writeln("Seconds since boot: ", sinceBoot);
 			scr.Writeln("Which means that the time should be: ", timestamp + sinceBoot);
+			break;
+
+		case "sleep":
+			ulong secs = 3; //TODO parse this from an argument
+			scr.Writeln("Sleeping for ", secs, " seconds");
+			GetScheduler.USleep(secs * 1000);
+			scr.Writeln("Done sleeping");
 			break;
 
 		case "ls":

--- a/Kernel/src/CPU/GDT.d
+++ b/Kernel/src/CPU/GDT.d
@@ -162,12 +162,12 @@ private:
 		SetData(idx++, true, 0);
 
 		// User
-		SetData(idx++, true, 3);
 		SetCode(idx++, true, 3, true);
+		SetData(idx++, true, 3);
 
 		tssID = cast(ushort)idx;
-		SetTSS(idx++, tss); // Uses 2 entries
-		idx++;
+		SetTSS(idx, tss); // Uses 2 entries
+		idx += 2;
 		return idx;
 	}
 }

--- a/Kernel/src/CPU/IDT.d
+++ b/Kernel/src/CPU/IDT.d
@@ -119,6 +119,7 @@ private:
 		mixin(addJumps!(0, 255));
 		add(3, SystemSegmentType.InterruptGate, cast(ulong)&isr3, 3, InterruptStackType.Debug);
 		add(8, SystemSegmentType.InterruptGate, cast(ulong)&isrIgnore, 0, InterruptStackType.RegisterStack);
+		//add(128, SystemSegmentType.InterruptGate, cast(ulong)&isr128, 3, InterruptStackType.RegisterStack);
 
 		Flush();
 	}
@@ -224,6 +225,7 @@ private:
 		import Data.TextBuffer : scr = GetBootTTY;
 		import IO.Log;
 
+		regs.IntNumber &= 0xFF;
 		if (32 <= regs.IntNumber && regs.IntNumber <= 48) {
 			if (regs.IntNumber >= 40)
 				Out!ubyte(0xA0, 0x20);

--- a/Kernel/src/CPU/PIT.d
+++ b/Kernel/src/CPU/PIT.d
@@ -4,6 +4,7 @@ import CPU.IDT;
 import IO.Port;
 import IO.Log;
 import Data.Register;
+import Task.Process;
 import Task.Scheduler;
 
 struct PIT {
@@ -42,6 +43,7 @@ private:
 
 		counter++;
 
+		GetScheduler.WakeUp(WaitReason.Timer, &wakeUpTimedSleep);
 		GetScheduler.SwitchProcess(true);
 		/*
 		const ulong usedMiB = FrameAllocator.UsedFrames / 256;
@@ -54,5 +56,12 @@ private:
 
 		GetScreen.WriteStatus("Memory used: ", usedMiB, "MiB/", maxMiB, "MiB(", memory, "%)\tPID: ", cast(void*)pid,
 				"\tSeconds since boot: ", Seconds);*/
+	}
+
+	static bool wakeUpTimedSleep(Process* p) {
+		p.waitData--;
+		if(p.waitData == 0)
+			return true;
+		return false;
 	}
 }

--- a/Kernel/src/IO/Keyboard.d
+++ b/Kernel/src/IO/Keyboard.d
@@ -1,11 +1,18 @@
 module IO.Keyboard;
 
+import Task.Process;
+import Task.Scheduler;
+
 struct Keyboard {
 public:
 	static wchar Pop() {
 		wchar ch = Peek();
-		if (ch)
-			start++;
+		while(!ch) {
+			GetScheduler.WaitFor(WaitReason.Keyboard);
+			ch = Peek();
+		}
+
+		start++;
 		return ch;
 	}
 
@@ -18,6 +25,7 @@ public:
 
 	static void Push(wchar ch) {
 		buffer[end++] = ch;
+		GetScheduler.WakeUp(WaitReason.Keyboard);
 	}
 
 private:

--- a/Kernel/src/Memory/Paging.d
+++ b/Kernel/src/Memory/Paging.d
@@ -197,7 +197,7 @@ class Paging {
 		return phys;
 	}
 
-	TablePtr!void* GetPage(VirtAddress virt) {
+	TablePtr!(void)* GetPage(VirtAddress virt) {
 		if (virt.Int == 0)
 			return null;
 		const ulong virtAddr = virt.Int;

--- a/Kernel/src/System/Syscall.d
+++ b/Kernel/src/System/Syscall.d
@@ -1,0 +1,80 @@
+module System.Syscall;
+
+import CPU.IDT;
+import Data.Register;
+
+struct Syscall {
+public:
+	static void Init() {
+		IDT.Register(0x80, &onSyscall);
+	}
+
+private:
+	static void onSyscall(Registers* regs) {
+		import Data.TextBuffer : scr = GetBootTTY;
+
+		with (regs) switch (RAX) {
+			foreach (func; __traits(derivedMembers, mixin(__MODULE__))) {
+				foreach (attr; __traits(getAttributes, mixin(func))) {
+					static if (is(typeof(attr) == SyscallEntry)) {
+		case attr.id:
+						mixin(generateFunctionCall!func);
+					}
+				}
+			}
+		default:
+			scr.Writeln("UNKNOWN SYSCALL: ", cast(void*)RAX);
+			regs.RAX = ulong.max;
+		}
+	}
+
+	static string generateFunctionCall(alias func)() {
+		if (!__ctfe) // Without this it tries to use _d_arrayappendT
+			return "";
+		enum ABI = ["RDI", "RSI", "RDX", "RCX", "R8", "R9", "R10", "R11"];
+
+		alias p = Parameters!(mixin(func));
+		string o = func ~ "(";
+
+		foreach (idx, val; p) {
+			static if (idx)
+				o ~= ", ";
+			o ~= "cast(" ~ val.stringof ~ ")" ~ ABI[idx];
+		}
+
+		o ~= ");";
+		return o;
+	}
+
+	template Parameters(func...) {
+		static if (is(typeof(&func[0]) Fsym : Fsym*) && is(Fsym == function))
+			static if (is(Fsym P == function))
+				alias Parameters = P;
+			else
+				static assert(0, "argument has no parameters");
+	}
+}
+
+private:
+
+struct SyscallEntry {
+	ulong id;
+	string name;
+	string description;
+}
+
+@SyscallEntry(0, "Exit", "This terminates the current running process")
+ulong exit(ulong errorcode) {
+	import Task.Scheduler : GetScheduler;
+
+	GetScheduler.Exit(errorcode);
+	return 0;
+}
+
+@SyscallEntry(1, "Yield", "Yield the current process")
+ulong yield() {
+	/*import Task.Scheduler : GetScheduler;
+
+	GetScheduler.Exit(errorcode);*/
+	return 0;
+}

--- a/Kernel/src/Task/Process.d
+++ b/Kernel/src/Task/Process.d
@@ -6,6 +6,8 @@ import Memory.Heap;
 
 extern (C) void switchToUserMode(ulong loc, ulong stack);
 
+alias PID = ulong;
+
 struct ThreadState {
 	VirtAddress rbp;
 	VirtAddress rsp;
@@ -29,7 +31,7 @@ enum ProcessState {
 }
 
 struct Process {
-	ulong pid;
+	PID pid;
 	string name;
 	string description;
 
@@ -38,6 +40,8 @@ struct Process {
 
 	ulong uid;
 	ulong gid;
+
+	PID parent;
 
 	ulong returnCode;
 	ProcessState state;

--- a/Kernel/src/Task/Process.d
+++ b/Kernel/src/Task/Process.d
@@ -30,6 +30,12 @@ enum ProcessState {
 	Exited
 }
 
+enum WaitReason {
+	Keyboard,
+	Timer
+	//more e.g. harddrive, networking, mutex...
+}
+
 struct Process {
 	PID pid;
 	string name;
@@ -45,6 +51,9 @@ struct Process {
 
 	ulong returnCode;
 	ProcessState state;
+
+	WaitReason wait;
+	ulong waitData;
 
 	// MUTEX LOCKS
 }

--- a/Kernel/src/Task/Process.d
+++ b/Kernel/src/Task/Process.d
@@ -26,6 +26,7 @@ struct ImageInformation {
 
 enum ProcessState {
 	Running,
+	Ready,
 	Waiting,
 	Exited
 }

--- a/Kernel/src/Task/Process.d
+++ b/Kernel/src/Task/Process.d
@@ -45,7 +45,6 @@ struct Process {
 
 	ulong returnCode;
 	ProcessState state;
-	bool active;
 
 	// MUTEX LOCKS
 }

--- a/Kernel/src/Task/Scheduler.d
+++ b/Kernel/src/Task/Scheduler.d
@@ -48,7 +48,6 @@ public:
 		if (storeRIP == SWITCH_MAGIC) // Swap is done
 			return;
 
-		current.active = false;
 		with (current.threadState) {
 			rbp = storeRBP;
 			rsp = storeRSP;
@@ -106,7 +105,6 @@ public:
 			image.stack = stack;
 
 			state = ProcessState.Running;
-			active = false;
 		}
 
 		processes.Add(process);
@@ -200,7 +198,6 @@ private:
 			image.stack = VirtAddress(&KERNEL_STACK_START) + 1 /*???*/ ;
 
 			state = ProcessState.Running;
-			active = true;
 		}
 	}
 
@@ -220,8 +217,6 @@ private:
 
 		current.threadState.paging.Install();
 		GDT.tss.RSP0 = current.image.stack;
-
-		current.active = true;
 
 		asm {
 			mov RAX, RBP; // RBP will be overritten below

--- a/Kernel/src/Task/Scheduler.d
+++ b/Kernel/src/Task/Scheduler.d
@@ -62,6 +62,7 @@ public:
 			}
 		}
 
+		current.state = ProcessState.Ready;
 		if (reschedule && current != idleProcess)
 			processes.Add(current);
 		doSwitching();
@@ -129,7 +130,7 @@ public:
 
 			image.stack = stack;
 
-			state = ProcessState.Running;
+			state = ProcessState.Ready;
 		}
 
 		processes.Add(process);
@@ -204,7 +205,7 @@ private:
 
 			image.stack = stack;
 
-			state = ProcessState.Running;
+			state = ProcessState.Ready;
 		}
 	}
 

--- a/Kernel/src/Task/Scheduler.d
+++ b/Kernel/src/Task/Scheduler.d
@@ -92,6 +92,10 @@ public:
 			SwitchProcess();
 	}
 
+	void USleep(ulong usecs) {
+		WaitFor(WaitReason.Timer, usecs);
+	}
+
 	PID Fork() {
 		// Clones everything
 		return PID.max;

--- a/Kernel/src/Task/Task.S
+++ b/Kernel/src/Task/Task.S
@@ -13,11 +13,15 @@ switchToUserMode: // RIP = %rdi, RSP = %rsi
 	mov %ax, %es
 	mov %ax, %fs
 	mov %ax, %gs
-	mov %ax, %ss
+	mov %rsi, %rsp
+
+	push $0x0
+	mov %rsp, %rax
+
 	push $USER_SS
 
 	// Stack pointer
-	push %rsi
+	push %rax
 
 	// FLAGS, Enabling interrupt
 	pushfq
@@ -62,3 +66,13 @@ fpuDisable:
 	movq %rcx, %cr4
 	ret
 .size fpuDisable, .-fpuDisable
+
+
+.global cloneHelper
+.type cloneHelper, %function
+cloneHelper:
+	pop %rax // Function
+	pop %rdi // Userdata
+	jmp %rax
+.size cloneHelper, .-cloneHelper
+

--- a/Kernel/src/object.d
+++ b/Kernel/src/object.d
@@ -136,7 +136,7 @@ extern (C) {
 
 	// the compiler spits this out all the time
 	Object _d_newclass(const ClassInfo ci) {
-		log.Debug("Creating a new class of type: ", ci.name);
+		//log.Debug("Creating a new class of type: ", ci.name);
 		void* memory = GetKernelHeap.Alloc(ci.init.length);
 		if (memory is null) {
 			log.Fatal("\n\n_d_newclass malloc failure\n\n");


### PR DESCRIPTION
When e.g. the shell waits for input (keyboard input in this case) it does busy waiting, by permanently checking if a new button has been pressed yet. This means that the CPU is running at max speed all the time. Instead the process should ``WaitFor` an interrupt.

Once i added WaitFor it was pretty easy to implement `usleep` too in 0a7e3c85a0e6b2431a93466c385eb969f95a1f67 I then also implemented a simple sleep command for the basic shell that waits 3 seconds. I wanted it to sleep seconds according to an argument but D is weird sometimes (Command argument was `char[]` but atoi expects `string` and `fromStringz` allocates memory and I am not sure if and how I have to free it.)