### PR TITLE
replace hacky SwapFd syscall by ANSI-C-freopen like ReOpen syscall

### DIFF
--- a/Kernel/src/Bin/Debugger.d
+++ b/Kernel/src/Bin/Debugger.d
@@ -1,0 +1,10 @@
+module Bin.Debugger;
+
+import Data.String;
+import CPU.IDT;
+import IO.Keyboard;
+import IO.Log;
+import IO.FS;
+
+class Debugger {
+}

--- a/Kernel/src/System/Syscall.d
+++ b/Kernel/src/System/Syscall.d
@@ -206,6 +206,8 @@ void ReOpen(size_t id, string file) {
 			return;
 		}
 	}
+
+	process.syscallRegisters.RAX = 1;
 }
 
 @SyscallEntry(SyscallID.Close)

--- a/Kernel/src/System/Syscall.d
+++ b/Kernel/src/System/Syscall.d
@@ -191,17 +191,19 @@ void ReOpen(size_t id, string file) {
 		return;
 	}
 
+
 	for (size_t i = 0; i < process.fileDescriptors.Length; i++) {
 		FileDescriptor* item = process.fileDescriptors.Get(i);
 		if (item.id == id) {
-			item.node.Close();
-
-			item.node = cast(FileNode)rootFS.Root.FindNode(file);
-			if (!item.node) {
+			FileNode newNode = cast(FileNode)rootFS.Root.FindNode(file);
+			if (!newNode) {
 				process.syscallRegisters.RAX = 1;
 				return;
 			}
 
+			item.node.Close();
+			item.node = newNode;
+			item.node.Open();
 			process.syscallRegisters.RAX = 0;
 			return;
 		}

--- a/Userspace/Init/src/app.d
+++ b/Userspace/Init/src/app.d
@@ -35,29 +35,19 @@ void Println(string str) {
 int main(string[] args) {
 	Println("Init system loading...");
 
-	size_t fd = Syscall.Open("/IO/Console/VirtualConsole4");
-	spawnShell(fd);
-	Syscall.Close(fd);
+	spawnShell("/IO/Console/VirtualConsole4");
+	spawnShell("/IO/Console/VirtualConsole3");
+	spawnShell("/IO/Console/VirtualConsole2");
+	spawnShell("/IO/Console/VirtualConsole1");
 
-	fd = Syscall.Open("/IO/Console/VirtualConsole3");
-	spawnShell(fd);
-	Syscall.Close(fd);
-
-	fd = Syscall.Open("/IO/Console/VirtualConsole2");
-	spawnShell(fd);
-	Syscall.Close(fd);
-
-	fd = Syscall.Open("/IO/Console/VirtualConsole1");
-	spawnShell(fd);
-	Syscall.Close(fd);
 	while (true)
 		Syscall.Join(0);
 }
 
-void spawnShell(size_t fd) {
+void spawnShell(string virtConsole) {
 	ulong pid = Syscall.Fork();
 	if (!pid) {
-		Syscall.SwapFD(0, fd);
+		Syscall.ReOpen(0, virtConsole);
 		Syscall.Exec("/Binary/Shell", []);
 		Syscall.Exit(1);
 	}


### PR DESCRIPTION
If i remember correctly you said yourself you dont like the current `SwapFd` thing because its "basically a big hack" (like everything? ^^)

when trying to implement the file functions for PowerNexLibc i came to the idea that `ReOpen` would be a more clean method allowing the same use.