### PR TITLE
Improve ls and the listDirectory syscall

### DIFF
--- a/kernel/src/system/syscall.d
+++ b/kernel/src/system/syscall.d
@@ -325,6 +325,12 @@ void listDirectory(string path, void* listings_, size_t len) {
 		nodes = node.nodes;
 	}
 
+	if(listings_ is null)
+	{
+		process.syscallRegisters.rax = nodes.length;
+		return;
+	}
+
 	auto length = nodes.length;
 	if (listings.length < length)
 		length = listings.length;

--- a/userspace/shell/src/app.d
+++ b/userspace/shell/src/app.d
@@ -181,7 +181,13 @@ private:
 			DirectoryListing[32] listings = void;
 			void* ptr = cast(void*)listings.ptr;
 			size_t len = listings.length;
-			size_t count = Syscall.listDirectory(ptr, len);
+			size_t count;
+
+			if(cmd.args.length == 1)
+				count = Syscall.listDirectory(null, ptr, len);
+			else
+				count = Syscall.listDirectory(cast(string)cmd.args[1], ptr, len);
+
 			println("ID\tName\t\tType");
 			foreach (list; listings[0 .. count]) {
 				char[ulong.sizeof * 8] buf;

--- a/userspace/shell/src/app.d
+++ b/userspace/shell/src/app.d
@@ -178,25 +178,30 @@ private:
 			break;
 
 		case "ls":
-			DirectoryListing[32] listings = void;
+			DirectoryListing[16] listings = void;
 			void* ptr = cast(void*)listings.ptr;
-			size_t len = listings.length;
-			size_t count;
 
-			if(cmd.args.length == 1)
-				count = Syscall.listDirectory(null, ptr, len);
-			else
-				count = Syscall.listDirectory(cast(string)cmd.args[1], ptr, len);
+			size_t curr = 0;
+			size_t count = listings.length;
 
 			println("ID\tName\t\tType");
-			foreach (list; listings[0 .. count]) {
-				char[ulong.sizeof * 8] buf;
-				print(itoa(list.id, buf, 10));
-				print(":\t");
-				print(list.name.fromStringz);
-				print("\t\t");
-				print(list.type);
-				println();
+
+			while(count == listings.length) {
+				if(cmd.args.length == 1)
+					count = Syscall.listDirectory(null, ptr, listings.length, curr);
+				else
+					count = Syscall.listDirectory(cast(string)cmd.args[1], ptr, listings.length, curr);
+
+				curr += listings.length;
+				foreach (list; listings[0 .. count]) {
+					char[ulong.sizeof * 8] buf;
+					print(itoa(list.id, buf, 10));
+					print(":\t");
+					print(list.name.fromStringz);
+					print("\t\t");
+					print(list.type);
+					println();
+				}
 			}
 			break;
 


### PR DESCRIPTION
- 08c7e6704b9ac42fe4aab4146d0f8c4974480df1 allows `ls` on a path that is not the current working directory
- 02095904b439375fa7ed1a0aab8e2caa0280050c allows getting the count of entries in a directory
- d9d30cb111bb569d01f0a8beb764513fc29b677b allows looping through the the entries in a directory with several `listDirectory` syscalls instead of one big one (also allows listing infinitly large directories with `ls`)